### PR TITLE
feat: 関数コンポーネントに対応した

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,14 +2,18 @@ import Ownact from './ownact';
 
 const container = document.getElementById('root');
 
-const element = (
-  <div id="foo">
-    <a>bar</a>
-    <b />
-    <c>
-      <d />
-    </c>
-  </div>
-);
+const App = () => {
+  return (
+    <div id="foo">
+      <a>bar</a>
+      <b />
+      <c>
+        <d />
+      </c>
+    </div>
+  )
+}
+
+const element = <App />;
 
 Ownact.render(element, container);


### PR DESCRIPTION
### 概要

関数コンポーネント対応。
関数コンポーネントが返すJSXの場合はJSXの変換ではdomがついていないので、domを持っている祖先ノードまで見に行って実DOMに追加する。
削除も子孫ノードを身にいって削除する。

### issue

### リンク